### PR TITLE
Suffix bei mehrsprachigen Domains beachten

### DIFF
--- a/lib/yrewrite_url_schemes.php
+++ b/lib/yrewrite_url_schemes.php
@@ -29,6 +29,33 @@ class yrewrite_url_schemes extends rex_yrewrite_scheme {
 		// Default
 		return parent::appendArticle($path, $art, $domain);
     }
+    
+    /**
+     * @param rex_article         $art
+     * @param rex_yrewrite_domain $domain
+     *
+     * @return string|false
+     */
+    public function getCustomUrl(rex_article $art, rex_yrewrite_domain $domain)
+    {
+        $path_suffix = rex_config::get('yrewrite_scheme', 'suffix');
+        if ($path_suffix == '.html') {
+            $path_suffix = '';
+        }
+
+        if ($domain->getStartId() == $art->getId()) {
+            if ($domain->getStartClang() == $art->getClang()) {
+                return '/';
+            }
+
+            return $this->getClang($art->getClang(), $domain) . $path_suffix;
+        }
+        if ($url = $art->getValue('yrewrite_url')) {
+            return $url;
+        }
+        return false;
+    }
+    
     /**
 	 * Append category name
      * @param string              $path

--- a/lib/yrewrite_url_schemes.php
+++ b/lib/yrewrite_url_schemes.php
@@ -40,7 +40,7 @@ class yrewrite_url_schemes extends rex_yrewrite_scheme {
     {
         $path_suffix = rex_config::get('yrewrite_scheme', 'suffix');
         if ($path_suffix == '.html') {
-            $path_suffix = '';
+            $path_suffix = '/';
         }
 
         if ($domain->getStartId() == $art->getId()) {

--- a/package.yml
+++ b/package.yml
@@ -1,5 +1,5 @@
 package: yrewrite_scheme
-version: '3.1.1'
+version: '3.1.2'
 author: Friends Of REDAXO
 supportpage: https://github.com/FriendsOfREDAXO/yrewrite_scheme/
 pages:


### PR DESCRIPTION
Funktion getCustomUrl() aus dem Basis Scheme übernommen unter Berücksichtigung des ausgewählten Suffix. Hintergrund ist, dass bei mehrsprachigen Seiten die Fehlerseite nicht korrekt ausgespielt wurde, da der Kontext zur Sprache bei dem Suffix `.html` verloren ging. Sollte dieser Suffix nun ausgewählt sein, lautet die URL des Startartikels in der Nichtstartsprache nun nicht mehr `en.html` sondern `en` plus dem ausgewählten Suffix. Dadurch können nun auch nicht vorhandene URL's aufgerufen werden, die auf die Fehlerseite der entsprechenden Sprache umleiten.