### PR TITLE
überflüssiges Config-Auslesen entfernt. Absatz über Suffix in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ stellt eine Auswahl von URL-Schemes für YRewrite zur Verfügung.
 
 Für jedes Schema können der Suffix, die passende **URL-Normalisierung je Sprache** und eine URL-Ersetzung gewählt werden. Andere AddOns, die eigene Schemes installieren, sollten vorab deaktiviert werden. Die Einstellungen findet man im zusätzlichen Reiter **YRewrite Scheme** in YRewrite. 
 
+## Suffix
+
+Hier kann der Suffix der URLs festgelegt werden.
+Zur Auswahl stehen:
+- "ohne"
+- ".html"
+- "/"
+
 ## Schemen
 
 ### 1. Standard

--- a/lib/yrewrite_url_schemes.php
+++ b/lib/yrewrite_url_schemes.php
@@ -33,15 +33,13 @@ class yrewrite_url_schemes extends rex_yrewrite_scheme
 
         if ($scheme == 'yrewrite_scheme_suffix') {
             // standard / suffix scheme
-            $path_suffix = rex_config::get('yrewrite_scheme', 'suffix');
             if ($art->isStartArticle() && $domain->getMountId() != $art->getId()) {
-                return $path . $path_suffix;
+                return $path . $this->suffix;
             }
-            return $path . '/' . $this->normalize($art->getName(), $art->getClang()) . $path_suffix;
+            return $path . '/' . $this->normalize($art->getName(), $art->getClang()) . $this->suffix;
         } else if ($scheme == 'yrewrite_one_level') {
             // one level scheme
-            $path_suffix = rex_config::get('yrewrite_scheme', 'suffix');
-            return $path . '/' . $this->normalize($art->getName(), $art->getClang()) . $path_suffix;
+            return $path . '/' . $this->normalize($art->getName(), $art->getClang()) . $this->suffix;
         }
 
         // Default
@@ -56,7 +54,7 @@ class yrewrite_url_schemes extends rex_yrewrite_scheme
      */
     public function getCustomUrl(rex_article $art, rex_yrewrite_domain $domain)
     {
-        $path_suffix = rex_config::get('yrewrite_scheme', 'suffix');
+        $path_suffix = $this->suffix;
         if ($path_suffix == '.html') {
             $path_suffix = '/';
         }


### PR DESCRIPTION
War mir heute aufgefallen als wir im Slack ein Problem bei jemandem besprochen haben, der eine eigene scheme-Datei nutzte .
Die Member-Variable $suffix wird ja hier https://github.com/FriendsOfREDAXO/yrewrite_scheme/blob/master/boot.php#L4 schon gesetzt.

Die Readme geändert, weil ich sonst den Suffix zu unauffällig finde. Dann bekommen vielleicht mehr Leute mit, dass man das AddOn dafür nutzen kann.