### PR TITLE
Fix: urlreplace scheme should not redirect mount point articles

### DIFF
--- a/lib/yrewrite_url_schemes.php
+++ b/lib/yrewrite_url_schemes.php
@@ -87,7 +87,7 @@ class yrewrite_url_schemes extends rex_yrewrite_scheme {
 		
 		if($urlreplacer == 'yrewrite_scheme_urlreplace') {
 			// urlreplace scheme
-			if ($art->isStartArticle() && ($cats = $art->getCategory()->getChildren(true)) && !rex_article_slice::getFirstSliceForCtype(1, $art->getId(), rex_clang::getCurrentId())) {
+			if ($art->isStartArticle() && $domain->getMountId() != $art->getId() && ($cats = $art->getCategory()->getChildren(true)) && !rex_article_slice::getFirstSliceForCtype(1, $art->getId(), rex_clang::getCurrentId())) {
 				return $cats[0];
 			}
 			return false;


### PR DESCRIPTION
The urlreplace scheme redirects start articles without slices to their first child category. This incorrectly affects mount point articles, causing them to get wrong URLs in the backend and pathlist cache.

Added mount point check consistent with the nomatter scheme.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Fehlerbehebungen**
  * Verbesserte Weiterleitungslogik bei der URL-Umschreibung durch zusätzliche Validierungsprüfung beim Umleiten zu untergeordneten Kategorien für eine zuverlässigere Funktionsweise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->