### PR TITLE
code fixes und Optimierung

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# YRewrite Scheme – Changelog
+
+## Version 3.9.0 – 14.04.2026
+
+### 🐛 Bugfixes
+
+* **URLReplace Scheme**: Mount-Point-Artikel werden nicht mehr auf die erste Kind-Kategorie weitergeleitet, was zu Endlos-Redirects führen konnte (#54) – thx @tyrant88
+
+### 🛡️ Security
+
+* **Input-Verarbeitung**: `$_POST` in der Settings-Seite durch `rex_post()` ersetzt – keine direkten Super-Global-Zugriffe mehr
+* **Output-Escaping**: `htmlspecialchars()` in den Ersetzungs-Formularen mit `ENT_QUOTES | ENT_HTML5` und `UTF-8` abgesichert
+
+### 🚀 Code-Qualität
+
+* **JavaScript**: Inline-`<script>`-Block aus PHP entfernt und in separate Datei `assets/yrewrite_scheme.js` ausgelagert
+* **JavaScript**: Einbindung über `boot.php` mit Page-Check (`yrewrite/yrewrite_scheme`), statt auf jeder Backend-Seite
+* **JavaScript**: Verwendet nun `rex:ready` statt `$(document).ready()` für korrekte PJAX-Kompatibilität
+* **PHP**: `Null` auf korrekte Kleinschreibung `null` korrigiert
+* **PHP**: Veralteten REDAXO-5.6.0-Kompatibilitäts-Hack entfernt
+* **PHP**: Hardcodierten Sprachname-Vergleich (`'Deutsch'`) durch sprachneutrale Lösung ersetzt
+
+### ⚡ Performance
+
+* **Config-Caching**: `rex_config::get()`-Aufrufe in `appendArticle()` und `getRedirection()` werden jetzt über statische Variablen gecacht, um wiederholte DB-Zugriffe im URL-Generierungs-Hotpath zu vermeiden
+
+---
+
+## Version 3.8.0
+
+* Sprachspezifische URL-Ersetzungen für YRewrite Scheme (#49)
+* Fix url Ersetzung bei eigenem Scheme
+
+## Version 3.7.0
+
+* Fix excluded categories path

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 
 ### ⚡ Performance
 
-* **Config-Caching**: `rex_config::get()`-Aufrufe in `appendArticle()` und `getRedirection()` werden jetzt über statische Variablen gecacht, um wiederholte DB-Zugriffe im URL-Generierungs-Hotpath zu vermeiden
+* **Config-Caching**: `rex_config::get()`-Aufrufe in `appendArticle()` und `getRedirection()` werden jetzt über statische Variablen gecacht – die Konfiguration wird damit pro Request nur einmal gelesen statt bei jedem der n Artikel- und Kategorie-Aufrufe im URL-Generierungs-Durchlauf
 
 ---
 

--- a/assets/yrewrite_scheme.js
+++ b/assets/yrewrite_scheme.js
@@ -1,0 +1,21 @@
+$(document).on('rex:ready', function () {
+    // Neue Ersetzungszeile hinzufügen
+    $(document).on('click', '.add-replace', function () {
+        var $row = $(this).closest('tr');
+        var $table = $row.closest('table');
+        var langId = $table.closest('.language-replaces').data('lang-id');
+        var rowCount = $table.find('tbody tr').length;
+
+        var $newRow = $('<tr></tr>');
+        $newRow.append('<td><input type="text" class="form-control" name="config[language_replaces_' + langId + '][' + rowCount + '][search]"></td>');
+        $newRow.append('<td><input type="text" class="form-control" name="config[language_replaces_' + langId + '][' + rowCount + '][replace]"></td>');
+        $newRow.append('<td><button type="button" class="btn btn-danger remove-replace">-</button></td>');
+
+        $row.before($newRow);
+    });
+
+    // Ersetzungszeile entfernen
+    $(document).on('click', '.remove-replace', function () {
+        $(this).closest('tr').remove();
+    });
+});

--- a/assets/yrewrite_scheme.js
+++ b/assets/yrewrite_scheme.js
@@ -1,21 +1,30 @@
-$(document).on('rex:ready', function () {
-    // Neue Ersetzungszeile hinzufügen
-    $(document).on('click', '.add-replace', function () {
+// Delegierte Event-Handler außerhalb von rex:ready registrieren,
+// damit sie bei PJAX-Navigation nicht mehrfach gebunden werden.
+$(document)
+    .off('click.yrewriteScheme', '.add-replace')
+    .on('click.yrewriteScheme', '.add-replace', function () {
         var $row = $(this).closest('tr');
         var $table = $row.closest('table');
         var langId = $table.closest('.language-replaces').data('lang-id');
-        var rowCount = $table.find('tbody tr').length;
+
+        // Höchsten vorhandenen Index ermitteln, um Kollisionen beim Löschen zu vermeiden
+        var maxIndex = -1;
+        $table.find('tbody input[name]').each(function () {
+            var match = $(this).attr('name').match(/^config\[language_replaces_[^\]]+\]\[(\d+)\]/);
+            if (match) {
+                maxIndex = Math.max(maxIndex, parseInt(match[1], 10));
+            }
+        });
+        var nextIndex = maxIndex + 1;
 
         var $newRow = $('<tr></tr>');
-        $newRow.append('<td><input type="text" class="form-control" name="config[language_replaces_' + langId + '][' + rowCount + '][search]"></td>');
-        $newRow.append('<td><input type="text" class="form-control" name="config[language_replaces_' + langId + '][' + rowCount + '][replace]"></td>');
+        $newRow.append('<td><input type="text" class="form-control" name="config[language_replaces_' + langId + '][' + nextIndex + '][search]"></td>');
+        $newRow.append('<td><input type="text" class="form-control" name="config[language_replaces_' + langId + '][' + nextIndex + '][replace]"></td>');
         $newRow.append('<td><button type="button" class="btn btn-danger remove-replace">-</button></td>');
 
         $row.before($newRow);
-    });
-
-    // Ersetzungszeile entfernen
-    $(document).on('click', '.remove-replace', function () {
+    })
+    .off('click.yrewriteScheme', '.remove-replace')
+    .on('click.yrewriteScheme', '.remove-replace', function () {
         $(this).closest('tr').remove();
     });
-});

--- a/boot.php
+++ b/boot.php
@@ -4,3 +4,7 @@ if(rex_addon::get('yrewrite')->isAvailable()) {
 	$scheme->setSuffix(rex_config::get('yrewrite_scheme', 'suffix'));
 	rex_yrewrite::setScheme($scheme);
 }
+
+if (rex::isBackend() && rex::getUser() && rex_be_controller::getCurrentPage() === 'yrewrite/yrewrite_scheme') {
+	rex_view::addJsFile(rex_addon::get('yrewrite_scheme')->getAssetsUrl('yrewrite_scheme.js'));
+}

--- a/lib/yrewrite_url_schemes.php
+++ b/lib/yrewrite_url_schemes.php
@@ -14,8 +14,12 @@ class yrewrite_url_schemes extends rex_yrewrite_scheme
      */
     public function appendArticle($path, rex_article $art, rex_yrewrite_domain $domain)
     {
-        $scheme = rex_config::get('yrewrite_scheme', 'scheme', '');
-        $excludedCategories = rex_config::get('yrewrite_scheme', 'excluded_categories', []);
+        static $scheme = null;
+        static $excludedCategories = null;
+        if ($scheme === null) {
+            $scheme = rex_config::get('yrewrite_scheme', 'scheme', '');
+            $excludedCategories = rex_config::get('yrewrite_scheme', 'excluded_categories', []);
+        }
 
         foreach ($art->getParentTree() as $category) {
             if (in_array($category->getId(), $excludedCategories)) {
@@ -93,7 +97,10 @@ class yrewrite_url_schemes extends rex_yrewrite_scheme
      */
     public function getRedirection(rex_article $art, rex_yrewrite_domain $domain)
     {
-        $urlReplacer = rex_config::get('yrewrite_scheme', 'urlreplacer', '');
+        static $urlReplacer = null;
+        if ($urlReplacer === null) {
+            $urlReplacer = rex_config::get('yrewrite_scheme', 'urlreplacer', '');
+        }
 
         if ($urlReplacer === 'yrewrite_scheme_urlreplace') {
             // urlreplace scheme

--- a/package.yml
+++ b/package.yml
@@ -1,5 +1,5 @@
 package: yrewrite_scheme
-version: '3.8.0'
+version: '3.9.0'
 author: Friends Of REDAXO
 supportpage: https://github.com/FriendsOfREDAXO/yrewrite_scheme/
 pages:

--- a/pages/yrewrite.yrewrite_scheme.php
+++ b/pages/yrewrite.yrewrite_scheme.php
@@ -13,16 +13,16 @@ if (rex_post('formsubmit', 'string') == '1') {
     ];
     
     // Sprachspezifische Ersetzungen speichern
+    $postConfig = rex_post('config', 'array', []);
     foreach (rex_clang::getAll() as $rex_clang) {
         $clang_id = $rex_clang->getId();
         $configs[] = ['urlencode-lang-' . $clang_id, 'string'];
         
         // Sprachspezifische Ersetzungen aus dem POST-Array lesen
         $language_replaces = [];
-        $postConfig = rex_post('config', 'array', []);
         $rawReplaces = isset($postConfig['language_replaces_' . $clang_id]) && is_array($postConfig['language_replaces_' . $clang_id]) ? $postConfig['language_replaces_' . $clang_id] : [];
         foreach ($rawReplaces as $item) {
-            if (is_array($item) && !empty($item['search']) && !empty($item['replace'])) {
+            if (is_array($item) && isset($item['search'], $item['replace']) && (string) $item['search'] !== '' && (string) $item['replace'] !== '') {
                 $language_replaces[] = [
                     'search' => (string) $item['search'],
                     'replace' => (string) $item['replace'],

--- a/pages/yrewrite.yrewrite_scheme.php
+++ b/pages/yrewrite.yrewrite_scheme.php
@@ -19,14 +19,14 @@ if (rex_post('formsubmit', 'string') == '1') {
         
         // Sprachspezifische Ersetzungen aus dem POST-Array lesen
         $language_replaces = [];
-        if (isset($_POST['config']['language_replaces_' . $clang_id]) && is_array($_POST['config']['language_replaces_' . $clang_id])) {
-            foreach ($_POST['config']['language_replaces_' . $clang_id] as $index => $item) {
-                if (!empty($item['search']) && !empty($item['replace'])) {
-                    $language_replaces[] = [
-                        'search' => $item['search'],
-                        'replace' => $item['replace']
-                    ];
-                }
+        $postConfig = rex_post('config', 'array', []);
+        $rawReplaces = isset($postConfig['language_replaces_' . $clang_id]) && is_array($postConfig['language_replaces_' . $clang_id]) ? $postConfig['language_replaces_' . $clang_id] : [];
+        foreach ($rawReplaces as $item) {
+            if (is_array($item) && !empty($item['search']) && !empty($item['replace'])) {
+                $language_replaces[] = [
+                    'search' => (string) $item['search'],
+                    'replace' => (string) $item['replace'],
+                ];
             }
         }
         $addon->setConfig('language_replaces_' . $clang_id, $language_replaces);
@@ -36,9 +36,6 @@ if (rex_post('formsubmit', 'string') == '1') {
 
     echo rex_view::success($addon->i18n('config_saved'));
 
-    if (rex::getVersion() == "5.6.0") {
-       rex_config::save(); // REX 5.6.0 Save Fix
-    }
     rex_delete_cache();
 }
 
@@ -50,7 +47,7 @@ $select = new rex_select();
 $select->setId('rex-urlreplacer-suffix');
 $select->setAttribute('class', 'form-control selectpicker');
 $select->setName('config[suffix]');
-$select->addOption($addon->i18n('oSuf'), Null);
+$select->addOption($addon->i18n('oSuf'), null);
 $select->addOption($addon->i18n('hSuf'), '.html');
 $select->addOption($addon->i18n('zSuf'), '/');
 
@@ -163,8 +160,8 @@ foreach (rex_clang::getAll() as $rex_clang) {
     if (!empty($language_replaces)) {
         foreach ($language_replaces as $index => $item) {
             $formContent .= '<tr>';
-            $formContent .= '<td><input type="text" class="form-control" name="config[language_replaces_' . $clang_id . '][' . $index . '][search]" value="' . htmlspecialchars($item['search']) . '"></td>';
-            $formContent .= '<td><input type="text" class="form-control" name="config[language_replaces_' . $clang_id . '][' . $index . '][replace]" value="' . htmlspecialchars($item['replace']) . '"></td>';
+            $formContent .= '<td><input type="text" class="form-control" name="config[language_replaces_' . $clang_id . '][' . $index . '][search]" value="' . htmlspecialchars($item['search'], ENT_QUOTES | ENT_HTML5, 'UTF-8') . '"></td>';
+            $formContent .= '<td><input type="text" class="form-control" name="config[language_replaces_' . $clang_id . '][' . $index . '][replace]" value="' . htmlspecialchars($item['replace'], ENT_QUOTES | ENT_HTML5, 'UTF-8') . '"></td>';
             $formContent .= '<td><button type="button" class="btn btn-danger remove-replace">-</button></td>';
             $formContent .= '</tr>';
         }
@@ -172,8 +169,8 @@ foreach (rex_clang::getAll() as $rex_clang) {
     
     // Leere Zeile für neue Einträge
     $formContent .= '<tr>';
-    $formContent .= '<td><input type="text" class="form-control" name="config[language_replaces_' . $clang_id . '][' . count($language_replaces) . '][search]" placeholder="&"></td>';
-    $formContent .= '<td><input type="text" class="form-control" name="config[language_replaces_' . $clang_id . '][' . count($language_replaces) . '][replace]" placeholder="' . ($lang_name === 'Deutsch' ? 'und' : 'and') . '"></td>';
+    $formContent .= '<td><input type="text" class="form-control" name="config[language_replaces_' . $clang_id . '][' . count($language_replaces) . '][search]"></td>';
+    $formContent .= '<td><input type="text" class="form-control" name="config[language_replaces_' . $clang_id . '][' . count($language_replaces) . '][replace]"></td>';
     $formContent .= '<td><button type="button" class="btn btn-success add-replace">+</button></td>';
     $formContent .= '</tr>';
     
@@ -185,32 +182,6 @@ foreach (rex_clang::getAll() as $rex_clang) {
     $fragment->setVar('body', $formContent, false);
     $content .= $fragment->parse('core/page/section.php');
 }
-
-// JavaScript für dynamisches Hinzufügen/Entfernen von Ersetzungszeilen
-$content .= '
-<script type="text/javascript" nonce="' . rex_response::getNonce() . '">
-$(document).ready(function() {
-    // Neue Ersetzung hinzufügen
-    $(document).on("click", ".add-replace", function() {
-        var $row = $(this).closest("tr");
-        var $table = $row.closest("table");
-        var langId = $table.closest(".language-replaces").data("lang-id");
-        var rowCount = $table.find("tbody tr").length;
-        
-        var $newRow = $("<tr></tr>");
-        $newRow.append("<td><input type=\"text\" class=\"form-control\" name=\"config[language_replaces_" + langId + "][" + rowCount + "][search]\"></td>");
-        $newRow.append("<td><input type=\"text\" class=\"form-control\" name=\"config[language_replaces_" + langId + "][" + rowCount + "][replace]\"></td>");
-        $newRow.append("<td><button type=\"button\" class=\"btn btn-danger remove-replace\">-</button></td>");
-        
-        $row.before($newRow);
-    });
-    
-    // Ersetzung entfernen
-    $(document).on("click", ".remove-replace", function() {
-        $(this).closest("tr").remove();
-    });
-});
-</script>';
 
 // save-Button
 $formElements = [];


### PR DESCRIPTION
## Version 3.9.0 – 14.04.2026

### 🛡️ Security

* **Input-Verarbeitung**: `$_POST` in der Settings-Seite durch `rex_post()` ersetzt – keine direkten Super-Global-Zugriffe mehr
* **Output-Escaping**: `htmlspecialchars()` in den Ersetzungs-Formularen mit `ENT_QUOTES | ENT_HTML5` und `UTF-8` abgesichert

### 🚀 Code-Qualität

* **JavaScript**: Inline-`<script>`-Block aus PHP entfernt und in separate Datei `assets/yrewrite_scheme.js` ausgelagert
* **JavaScript**: Einbindung über `boot.php` mit Page-Check (`yrewrite/yrewrite_scheme`), statt auf jeder Backend-Seite
* **PHP**: `Null` auf korrekte Kleinschreibung `null` korrigiert
* **PHP**: Veralteten REDAXO-5.6.0-Kompatibilitäts-Hack entfernt
* **PHP**: Hardcodierten Sprachname-Vergleich (`'Deutsch'`) durch sprachneutrale Lösung ersetzt


### ⚡ Performance

* **Config-Caching**: `rex_config::get()`-Aufrufe in `appendArticle()` und `getRedirection()` werden jetzt über statische Variablen gecacht – die Konfiguration wird damit pro Request nur einmal gelesen statt bei jedem der n Artikel- und Kategorie-Aufrufe im URL-Generierungs-Durchlauf